### PR TITLE
Adding submit-application.sh script to simplify submission process

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,1 +1,2 @@
 *.env
+.docker

--- a/tools/hardhat/README.md
+++ b/tools/hardhat/README.md
@@ -14,10 +14,10 @@ npm install
 
 Hardhat is configured with the following supported networks:
 
-* `mezo_testnet` for connecting to the public testnet.
+* `testnet` for connecting to the public testnet.
 * `mainnet` soon..
 
-All tasks and scripts support hardhat's global options which includes the `--network` flag. `mezo_testnet` is
+All tasks and scripts support hardhat's global options which includes the `--network` flag. `testnet` is
 used by default if no network is set. If running a task or script against `mainnet` ensure you include
 `--network mainnet` as a hardhat argument.
 
@@ -95,7 +95,7 @@ validatorPool:validator: Returns a validator's consensus public key & descriptio
 Here we can see the validatorPool:validator task has an operator argument - correct usage would be:
 
 ```bash
-npx hardhat --network mezo_testnet validatorPool:validator --operator 0xc2f7Ae302a68CF215bb3dA243dadAB3290308015
+npx hardhat --network testnet validatorPool:validator --operator 0xc2f7Ae302a68CF215bb3dA243dadAB3290308015
 ```
 
 ### Running Tasks
@@ -104,7 +104,7 @@ Tasks get run as if they are built in hardhat commands. Read tasks are executed 
 (no account), e.g:
 
 ```bash
-npx hardhat --network mezo_testnet validatorPool:submitApplication --signer <validator address> --conspubkey <validator consensus address> --moniker <mezod moniker>
+npx hardhat --network testnet validatorPool:submitApplication --signer <validator address> --conspubkey <validator consensus address> --moniker <mezod moniker>
 ```
 
 ### How to Submit an application to Validator Pool
@@ -112,20 +112,16 @@ npx hardhat --network mezo_testnet validatorPool:submitApplication --signer <val
 Here is a step by step guide on how to submit an application to the PoA validator pool.
 
 ```bash
-# install dependencies
-cd tools/hardhat
-npm install
-
 # set your private key
 npx hardhat vars set MEZO_ACCOUNTS <your private key>
 
-# check your private key
-npx hardhat vars get MEZO_ACCOUNTS
+# fund your account
 
-# submit an application to the validator pool. Make sure you have funds on your
-# account to pay for the transaction fee.
-npx hardhat --network mezo_testnet validatorPool:submitApplication --signer <your validator address> --conspubkey <your consensus address> --moniker <your moniker>
+# submit your application to the validator pool. Available flags:
+# --flow (docker|native) This is mandatory
+# --network (testnet) Thi is optional, it defaults to testnet
+./submit-application.sh --flow docker
 
-# check your application
-npx hardhat --network mezo_testnet validatorPool:application --signer <your validator address>
+# you can check your application
+npx hardhat --network testnet validatorPool:application --signer <your validator address>
 ```

--- a/tools/hardhat/hardhat.config.ts
+++ b/tools/hardhat/hardhat.config.ts
@@ -42,9 +42,9 @@ const config: HardhatUserConfig = {
       evmVersion: 'cancun'
     }
   },
-  defaultNetwork: 'mezo_testnet',
+  defaultNetwork: 'testnet',
   networks: {
-    mezo_testnet: {
+    testnet: {
       url: 'http://mezo-node-0.test.mezo.org:8545',
       chainId: 31611,
       accounts: getPrivKeys()

--- a/tools/hardhat/submit-application.sh
+++ b/tools/hardhat/submit-application.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Default network value
+DOCKER_DIR="../../docker"
+NATIVE_DIR="../../native"
+HOME_DIR="$(pwd)"
+NETWORK="testnet" # default
+FLOW=""
+
+# install dependencies
+npm i
+
+# Function to display usage
+usage() {
+  echo "Usage: $0 [--network <network>] --flow <flow_value>"
+  exit 1
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --network)
+      NETWORK="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --flow)
+      FLOW="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+# Check if mandatory field is set
+if [ -z "$FLOW" ]; then
+  echo "Error: --flow is a mandatory flag."
+  usage
+fi
+
+# Output the values used
+echo "Network: $NETWORK"
+echo "Flow: $FLOW"
+
+# Specify the path to the *.env file (e.g. testnet.env)
+env_file="$NETWORK.env"
+
+if [ "$FLOW" = "docker" ]; then
+    cd $DOCKER_DIR || { echo "Failed to navigate to docker directory"; exit 1; }
+    output=$(./v-kit.sh validator-info)
+    # Extract MEZOD_MONIKER from the env file
+    moniker=$(grep "^MEZOD_MONIKER=" "$env_file" | awk -F'=' '{print $2}')
+elif [ "$FLOW" = "native" ]; then
+    cd $NATIVE_DIR || { echo "Failed to navigate to native directory"; exit 1; }
+    output=$(sudo ./v-kit.sh --validator-info)
+    # Extract MEZOD_MONIKER from the env file
+    moniker=$(grep "^MEZOD_MONIKER=" "$env_file" | awk -F'=' '{print $2}')
+else
+    echo "Error: Invalid flow value. Please use 'docker' or 'native'."
+    exit 1
+fi
+cd $HOME_DIR
+
+# Extract "Validator address"
+signer=$(echo "$output" | grep "Validator address" | awk -F': ' '{print $2}')
+
+# Extract "Validator consensus address"
+conspubkey=$(echo "$output" | grep "Validator consensus address" | awk -F': ' '{print $2}')
+
+moniker=${moniker#\"} #trim quotes
+moniker=${moniker%\"} #trim quotes
+
+# Print the extracted values
+echo "Validator address: $signer"
+echo "Validator consensus address: $conspubkey"
+echo "Moniker: $moniker"
+
+
+# Run the hardhat command with the extracted values. 
+
+# Important!
+# Make sure signer's private key is set. > npx hardhat vars set MEZO_ACCOUNTS <your private key>
+# Make sure your signer has funds to execute this transaction.
+
+npx hardhat --network $NETWORK validatorPool:submitApplication --signer $signer --conspubkey $conspubkey --moniker $moniker


### PR DESCRIPTION
This script should read the Validator address and Consensus Address from the v-kit.sh scripts so that users won't have to do that manually. The only thing that users should do is to add their private keys for transactions execution and make sure they have funds.

Once they add their priv keys and have funds on their account, it would be enough to call the below to command to submit their application.

```bash
./submit-application.sh --flow (docker|native) 
```