### PR TITLE
docker: Build CLI image before start

### DIFF
--- a/docker/v-kit.sh
+++ b/docker/v-kit.sh
@@ -109,6 +109,7 @@ init-genval() { ## Generate validator key
 # Runtime
 ################################################################################
 start() { ## Start the node
+  _build_cli_image
   ${DOCKER_COMPOSE_CMD} up --detach --force-recreate
 }
 


### PR DESCRIPTION
`start` pulls all images defined in compose.yaml. We need to make sure that CLI image is already available locally. Otherwise it fails with:
```
✘ cli Error          pull access denied for local/mezod-cli, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```