### PR TITLE
Replacing --signer with --operator in README

### DIFF
--- a/tools/hardhat/README.md
+++ b/tools/hardhat/README.md
@@ -122,5 +122,5 @@ Here is a step by step guide on how to submit an application to the PoA validato
 ./submit-application.sh --flow docker
 
 # you can check your application
-npx hardhat --network testnet validatorPool:application --signer <your validator address>
+npx hardhat --network testnet validatorPool:application --operator <your validator address>
 ```


### PR DESCRIPTION
There is a misleading info how to run a `validatorPool:application` task in Readme. The required flag is `--operator`, not `--signer`. This PR fixes it.
