### PR TITLE
fix(docker): set permissions for storage dir

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -57,10 +57,12 @@ cp testnet.env.example testnet.env
 * `NETWORK` - the network you want to join (`testnet` or `mainnet`)
 * `DOCKER_IMAGE` - the latest version of mezod image
 * `LOCAL_BIND_PATH` - the path to the local directory where the data will be stored
-  Make sure that the directory is created.
+  Make sure that the directory is created
+  and owned by the user with UID 65532 and GID 65532 ([user inside container](./compose.yaml#21)).
 
   ```shell
   mkdir -p /path/to/local/data
+  sudo chown -R 65532:65532 /path/to/local/data
   ```
 
 * `KEYRING_PASSWORD` - the password for the keyring. It is used to encrypt the key.


### PR DESCRIPTION
This pull request includes a small change to the `docker/README.md` file. The change clarifies the ownership requirements for the local directory used by the Docker container.

Documentation update:

* [`docker/README.md`](diffhunk://#diff-da8fcbe728a9172b578e5d754f8e2df214c658c4321f610e63dd68bea828ab49L60-R65): Added instructions to ensure the local directory is owned by the user with UID 65532 and GID 65532, including an example command to change ownership.