### PR TITLE
Adjusting validator info namings and how we extract moniker

### DIFF
--- a/native/v-kit.sh
+++ b/native/v-kit.sh
@@ -412,13 +412,13 @@ show_validator_info() {
     operator_address="$(${MEZO_EXEC} --home="${MEZOD_HOME}" keys parse "${raw_operator_address}" | grep bytes | awk '{print "0x"$2}' | tr '[:upper:]' '[:lower:]')"
     conspubkey=$(echo -n $parsed_raw_conspubkey | tr '[:upper:]' '[:lower:]' | xargs -I {} echo 0x{})
 
-    validator_network_addr="$(jq -r '.address' "${MEZOD_HOME}"/config/priv_validator_key.json | tr '[:upper:]' '[:lower:]' | awk '{print "0x"$1}')"
+    validator_consensus_addr="$(jq -r '.address' "${MEZOD_HOME}"/config/priv_validator_key.json | tr '[:upper:]' '[:lower:]' | awk '{print "0x"$1}')"
 
     echo "Your validator addresses info:"
     echo "Validator address: ${operator_address}"
     echo "Validator ID: ${validator_id}"
-    echo "Validator consensus address: ${conspubkey}"
-    echo "Validator network address: ${validator_network_addr}"
+    echo "Validator consensus pubkey: ${conspubkey}"
+    echo "Validator consensus address: ${validator_consensus_addr}"
     echo "Moniker: $MEZOD_MONIKER"
 }
 

--- a/tools/hardhat/submit-application.sh
+++ b/tools/hardhat/submit-application.sh
@@ -51,12 +51,10 @@ env_file="$NETWORK.env"
 if [ "$FLOW" = "docker" ]; then
     cd $DOCKER_DIR || { echo "Failed to navigate to docker directory"; exit 1; }
     output=$(./v-kit.sh validator-info)
-    moniker=$(grep "^MEZOD_MONIKER=" "$env_file" | awk -F'=' '{print $2}')
     priv_key=$(./v-kit.sh export-private-key)
 elif [ "$FLOW" = "native" ]; then
     cd $NATIVE_DIR || { echo "Failed to navigate to native directory"; exit 1; }
     output=$(sudo ./v-kit.sh --validator-info)
-    moniker=$(grep "^MEZOD_MONIKER=" "$env_file" | awk -F'=' '{print $2}')
     priv_key=$(sudo ./v-kit.sh export-private-key | tail -n 1)
 else
     echo "Error: Invalid flow value. Please use 'docker' or 'native'."
@@ -67,15 +65,15 @@ cd $HOME_DIR
 # Extract "Validator address"
 signer=$(echo "$output" | grep "Validator address" | awk -F': ' '{print $2}')
 
-# Extract "Validator consensus address"
-conspubkey=$(echo "$output" | grep "Validator consensus address" | awk -F': ' '{print $2}')
+# Extract "Validator consensus pubkey"
+conspubkey=$(echo "$output" | grep "Validator consensus pubkey" | awk -F': ' '{print $2}')
 
-moniker=${moniker#\"} #trim quotes
-moniker=${moniker%\"} #trim quotes
+# Extract "Moniker"
+moniker=$(echo "$output" | grep "Moniker" | awk -F': ' '{print $2}')
 
-# Print the extracted values
+# Print extracted values
 echo "Validator address: $signer"
-echo "Validator consensus address: $conspubkey"
+echo "Validator consensus pubkey: $conspubkey"
 echo "Moniker: $moniker"
 # echo "Private key: $priv_key"
 


### PR DESCRIPTION
Closes https://github.com/mezo-org/validator-kit/issues/8

- Validator consensus address -> Validator consensus pubkey
- Validator network address -> Validator consensus address
- Moniker is extracted now from `validator-info` command, not from the `testnet.env` file
- Echoing proper namings