### PR TITLE
Add connect-sidecar to Helm chart

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -61,10 +61,11 @@ services:
     # Dockerfile: https://github.com/skip-mev/connect/blob/main/contrib/images/connect.sidecar.prod.Dockerfile
     <<: [*platform, *logging]
     container_name: connect-sidecar
-    image: ghcr.io/skip-mev/connect-sidecar:v2.1.1
+    image: ghcr.io/skip-mev/connect-sidecar:v2.1.2
     entrypoint: []
     command:
       - connect
+      - --disable-telemetry
       - --log-disable-file-rotation
       - --port=8080
       - --market-map-endpoint=mezod:9090

--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 0.0.4
+version: 0.0.5
 appVersion: v0.2.0-rc1

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -35,7 +35,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![AppVersion: v0.2.0-rc1](https://img.shields.io/badge/AppVersion-v0.2.0--rc1-informational?style=flat-square)
+![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![AppVersion: v0.2.0-rc1](https://img.shields.io/badge/AppVersion-v0.2.0--rc1-informational?style=flat-square)
 
 ## Values
 

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -87,4 +87,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 | maintenanceMode | bool | `false` | Run shell in the container instead of the mezod process |
 | priorityClassName | string | `""` |  |
 | labels | object | `{}` |  |
+| connectSidecar.image | string | `"ghcr.io/skip-mev/connect-sidecar"` |  |
+| connectSidecar.tag | string | `"v2.1.2"` |  |
+| connectSidecar.ports.http | int | `8080` |  |
 

--- a/helm-chart/mezod/templates/configmap.yaml
+++ b/helm-chart/mezod/templates/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
   name: "custom-configs-{{ include "this.name" . }}"
   labels:
     {{- include "this.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   {{- if .Values.customConfigs.appTomlTxt }}
   app.toml.txt: |

--- a/helm-chart/mezod/templates/service-private.yaml
+++ b/helm-chart/mezod/templates/service-private.yaml
@@ -6,6 +6,9 @@ metadata:
   name: "private-{{ include "this.name" . }}"
   labels:
     {{- include "this.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   selector:

--- a/helm-chart/mezod/templates/service-public.yaml
+++ b/helm-chart/mezod/templates/service-public.yaml
@@ -6,6 +6,9 @@ metadata:
   name: "public-{{ include "this.name" . }}"
   labels:
     {{- include "this.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- with .Values.service.public.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/helm-chart/mezod/templates/serviceaccount.yaml
+++ b/helm-chart/mezod/templates/serviceaccount.yaml
@@ -4,4 +4,7 @@ metadata:
   name: {{ include "this.name" . | quote }}
   labels:
     {{- include "this.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 automountServiceAccountToken: false

--- a/helm-chart/mezod/templates/statefulset.yaml
+++ b/helm-chart/mezod/templates/statefulset.yaml
@@ -45,6 +45,9 @@ spec:
             name: "custom-configs-{{ include "this.name" . }}"
         {{- end }}
       containers:
+        #
+        # The main container with the mezod application
+        #
         - name: mezod
           image: "{{ .Values.image }}:{{ .Values.tag }}"
           imagePullPolicy: IfNotPresent
@@ -108,6 +111,9 @@ spec:
             - name: custom-configs
               mountPath: /config/
             {{- end }}
+        #
+        # The sidecar container for ethereum
+        #
         - name: ethereum-sidecar
           image: "{{ .Values.image }}:{{ .Values.tag }}"
           imagePullPolicy: IfNotPresent
@@ -133,6 +139,31 @@ spec:
           volumeMounts:
             - name: dummy-data
               mountPath: /tmp/dummy-data
+        #
+        # The sidecar container for Skip connect application
+        #
+        - name: connect-sidecar
+          image: "{{ .Values.connectSidecar.image }}:{{ .Values.connectSidecar.tag }}"
+          imagePullPolicy: IfNotPresent
+          command:
+            - connect
+            - --disable-telemetry
+            - --log-disable-file-rotation
+            - --port={{ .Values.connectSidecar.ports.http }}
+            - --market-map-endpoint=localhost:{{ .Values.service.public.ports.grpc }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.connectSidecar.ports.http }}
+              protocol: TCP
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            allowPrivilegeEscalation: false
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -87,3 +87,10 @@ maintenanceMode: false
 priorityClassName: ""
 
 labels: {}
+
+connectSidecar:
+  # Dockerfile: https://github.com/skip-mev/connect/blob/main/contrib/images/connect.sidecar.prod.Dockerfile
+  image: "ghcr.io/skip-mev/connect-sidecar"
+  tag: "v2.1.2"
+  ports:
+    http: 8080


### PR DESCRIPTION
This PR
- adds labels to all resources
- adds Skip `connect-sidecar` to the Statefulset without some default parameters.

Skip is not yet implemented in `mezod`. However, as a preparation step `connect-sidecar` can be running.

### Testing

This PR has been tested by me on my validator.

Connect-sidecar returns:
```{"level":"error","ts":"2024-12-04T12:10:29.278Z","caller":"marketmap/fetcher.go:104","msg":"failed to query market map module on node","pid":1,"process":"oracle","fetcher":"marketmap_api","error":"rpc error: code = Unimplemented desc = unknown service connect.marketmap.v2.Query"}```

but I assume it's ok for now since it's not yet implemented on the `mezod` side.