### PR TITLE
Adjust Docker deployment for mnemonic

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -73,6 +73,14 @@ cp testnet.env.example testnet.env
   openssl rand -hex 32
   ```
 
+* `KEYRING_MNEMONIC` - the mnemonic phrase.
+
+  Generate a new mnemonic phrase using the following command:
+
+  ```shell
+  ./v-kit.sh generate-mnemonic
+  ```
+
 * `MEZOD_MONIKER` - the name of the validator
 * `MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS` - the address of the Ethereum node
 * `PUBLIC_IP` - the public IP address of the validator

--- a/docker/testnet.env.example
+++ b/docker/testnet.env.example
@@ -19,8 +19,8 @@ LOCAL_BIND_PATH=/var/mezod
 # Keyring
 #
 KEYRING_NAME="localkey"
-KEYRING_PASSWORD="<change me>" # Can be generated using: openssl rand -hex 32
-#KEYRING_MNEMONIC - can be loaded from env or from user input or generated
+KEYRING_PASSWORD="<change me>" # Can be generated. Check out README.md
+KEYRING_MNEMONIC="<change me>" # Can be generated. Check out README.md
 
 #
 # Mezod

--- a/docker/v-kit.sh
+++ b/docker/v-kit.sh
@@ -58,6 +58,7 @@ _run_cli_cmd_oneshoot() {
 # Development and Operations
 ################################################################################
 shell() { ## Start a shell session
+  _build_cli_image
   ${DOCKER_COMPOSE_CMD} run --rm --interactive cli /bin/bash
 }
 
@@ -87,6 +88,12 @@ EOF
 export-private-key() { ## Export private key
   _run_cli_cmd_oneshoot <<'EOF'
 yes $KEYRING_PASSWORD | mezod --home="${MEZOD_HOME}" keys unsafe-export-eth-key "${KEYRING_NAME}" 2>/dev/null
+EOF
+}
+
+generate-mnemonic() { ## Generate a new mnemonic
+  _run_cli_cmd_oneshoot <<EOF
+mezod --home="${MEZOD_HOME}" keys mnemonic
 EOF
 }
 


### PR DESCRIPTION
Adjust README.md, testnet.env.example, and v-kit.sh to include instructions on how to generate a new mnemonic phrase.

This is because of https://github.com/mezo-org/mezod/pull/354