### PR TITLE
Improve Helm chart release GHA

### DIFF
--- a/.github/workflows/checks-pr.yaml
+++ b/.github/workflows/checks-pr.yaml
@@ -22,4 +22,6 @@ jobs:
             echo "Release not found."
             exit 0
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/checks-pr.yaml
+++ b/.github/workflows/checks-pr.yaml
@@ -1,0 +1,25 @@
+---
+name: Pull Requests Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  helm-chart-release-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏧 Checkout
+        uses: actions/checkout@v4
+      - name: 👁️ Check if the version of the Helm chart has been increased
+        run: |
+          version="$(grep "version:" helm-chart/mezod/Chart.yaml | cut -d ' ' -f 2 | tr -d '"')"
+          if gh release view "mezod-$version" >/dev/null 2>&1; then
+            echo "Release found. Update Chart.yaml version."
+            exit 1
+          else
+            echo "Release not found."
+            exit 0
+          fi
+

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -4,7 +4,7 @@ name: Checks
 on: push
 
 jobs:
-  helm-chart-version:
+  helm-chart-app-version:
     runs-on: ubuntu-latest
     steps:
       - name: 🏧 Checkout

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "helm-chart/**"
 
 jobs:
   release:

--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 0.0.3
+version: 0.0.4
 appVersion: v0.2.0-rc1

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -35,7 +35,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![AppVersion: v0.2.0-rc1](https://img.shields.io/badge/AppVersion-v0.2.0--rc1-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![AppVersion: v0.2.0-rc1](https://img.shields.io/badge/AppVersion-v0.2.0--rc1-informational?style=flat-square)
 
 ## Values
 


### PR DESCRIPTION
Add GHA for checking if the Helm chart release already exists. Any change in the Helm chart requires to increase the version. Example fail: https://github.com/mezo-org/validator-kit/actions/runs/12196696106/job/34024809367?pr=23
[Previous PR](https://github.com/mezo-org/validator-kit/pull/22) failed because of this.

