### PR TITLE
Adding custom port setup for P2P connection

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -76,7 +76,7 @@ cp testnet.env.example testnet.env
 * `MEZOD_MONIKER` - the name of the validator
 * `MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS` - the address of the Ethereum node
 * `PUBLIC_IP` - the public IP address of the validator
-* `MEZOD_P2P_PORT` - the port for the P2P connection. Default is `26656`
+* `MEZOD_PORT_P2P` - the port for the P2P connection. Default is `26656`
 
 ### 2. Initialization
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -76,6 +76,7 @@ cp testnet.env.example testnet.env
 * `MEZOD_MONIKER` - the name of the validator
 * `MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS` - the address of the Ethereum node
 * `PUBLIC_IP` - the public IP address of the validator
+* `MEZOD_P2P_PORT` - the port for the P2P connection. Default is `26656`
 
 ### 2. Initialization
 

--- a/docker/testnet.env.example
+++ b/docker/testnet.env.example
@@ -31,4 +31,4 @@ MEZOD_MONIKER="<change me>"
 MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS="<change me>"
 MEZOD_LOG_LEVEL=info
 MEZOD_LOG_FORMAT=plain # json|plain
-MEZOD_P2P_PORT=26656 # Default. It should be changed in case of a custom setup
+MEZOD_PORT_P2P=26656 # Default. It should be changed in case of a custom setup

--- a/docker/testnet.env.example
+++ b/docker/testnet.env.example
@@ -31,3 +31,4 @@ MEZOD_MONIKER="<change me>"
 MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS="<change me>"
 MEZOD_LOG_LEVEL=info
 MEZOD_LOG_FORMAT=plain # json|plain
+MEZOD_P2P_PORT=26656 # Default. It should be changed in case of a custom setup

--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 0.0.4
+version: 0.0.5
 appVersion: v0.2.0-rc1

--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 0.0.5
+version: 0.0.6
 appVersion: v0.2.0-rc1

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -54,7 +54,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 | env.MEZOD_CUSTOM_CONF_APP_TOML | string | `"/config/app.toml.txt"` |  |
 | env.MEZOD_CUSTOM_CONF_CLIENT_TOML | string | `"/config/client.toml.txt"` |  |
 | env.MEZOD_CUSTOM_CONF_CONFIG_TOML | string | `"/config/config.toml.txt"` |  |
-| env.MEZOD_PORT_P2P | string | `"26656 CHANGE_ME_IF_CUSTOM_SETUP"` |  |
+| env.MEZOD_PORT_P2P | int | `26656` |  |
 | secret | string | `"NAME_OF_THE_SECRET"` | Set Secret object containing the keyring information: KEYRING_NAME, KEYRING_PASSWORD, KEYRING_MNEMONIC and ETHEREUM_ENDPOINT |
 | storage.className | string | `"CHANGE_ME"` |  |
 | storage.size | string | `"1Gi"` |  |
@@ -71,7 +71,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 | service.public.type | string | `"LoadBalancer"` |  |
 | service.public.loadBalancerIP | string | `""` |  |
 | service.public.allocateLoadBalancerNodePorts | bool | `false` |  |
-| service.public.ports.p2p | int | `26656 CHANGE_ME_IF_CUSTOM_SETUP` |  |
+| service.public.ports.p2p | int | `26656` |  |
 | service.public.ports.rpc | int | `26657` |  |
 | service.public.ports.api | int | `1317` |  |
 | service.public.ports.grpc | int | `9090` |  |

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -54,6 +54,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 | env.MEZOD_CUSTOM_CONF_APP_TOML | string | `"/config/app.toml.txt"` |  |
 | env.MEZOD_CUSTOM_CONF_CLIENT_TOML | string | `"/config/client.toml.txt"` |  |
 | env.MEZOD_CUSTOM_CONF_CONFIG_TOML | string | `"/config/config.toml.txt"` |  |
+| env.MEZOD_P2P_PORT | string | `"26656 CHANGE_ME_IF_CUSTOM_SETUP"` |  |
 | secret | string | `"NAME_OF_THE_SECRET"` | Set Secret object containing the keyring information: KEYRING_NAME, KEYRING_PASSWORD, KEYRING_MNEMONIC and ETHEREUM_ENDPOINT |
 | storage.className | string | `"CHANGE_ME"` |  |
 | storage.size | string | `"1Gi"` |  |
@@ -70,7 +71,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 | service.public.type | string | `"LoadBalancer"` |  |
 | service.public.loadBalancerIP | string | `""` |  |
 | service.public.allocateLoadBalancerNodePorts | bool | `false` |  |
-| service.public.ports.p2p | int | `26656` |  |
+| service.public.ports.p2p | int | `26656 CHANGE_ME_IF_CUSTOM_SETUP` |  |
 | service.public.ports.rpc | int | `26657` |  |
 | service.public.ports.api | int | `1317` |  |
 | service.public.ports.grpc | int | `9090` |  |

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -35,7 +35,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![AppVersion: v0.2.0-rc1](https://img.shields.io/badge/AppVersion-v0.2.0--rc1-informational?style=flat-square)
+![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![AppVersion: v0.2.0-rc1](https://img.shields.io/badge/AppVersion-v0.2.0--rc1-informational?style=flat-square)
 
 ## Values
 

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -54,7 +54,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 | env.MEZOD_CUSTOM_CONF_APP_TOML | string | `"/config/app.toml.txt"` |  |
 | env.MEZOD_CUSTOM_CONF_CLIENT_TOML | string | `"/config/client.toml.txt"` |  |
 | env.MEZOD_CUSTOM_CONF_CONFIG_TOML | string | `"/config/config.toml.txt"` |  |
-| env.MEZOD_P2P_PORT | string | `"26656 CHANGE_ME_IF_CUSTOM_SETUP"` |  |
+| env.MEZOD_PORT_P2P | string | `"26656 CHANGE_ME_IF_CUSTOM_SETUP"` |  |
 | secret | string | `"NAME_OF_THE_SECRET"` | Set Secret object containing the keyring information: KEYRING_NAME, KEYRING_PASSWORD, KEYRING_MNEMONIC and ETHEREUM_ENDPOINT |
 | storage.className | string | `"CHANGE_ME"` |  |
 | storage.size | string | `"1Gi"` |  |

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -17,7 +17,7 @@ env:
   MEZOD_CUSTOM_CONF_APP_TOML: /config/app.toml.txt
   MEZOD_CUSTOM_CONF_CLIENT_TOML: /config/client.toml.txt
   MEZOD_CUSTOM_CONF_CONFIG_TOML: /config/config.toml.txt
-  MEZOD_P2P_PORT: 26656 # Default. It should be changed in case of a custom setup
+  MEZOD_PORT_P2P: 26656 # Default. It should be changed in case of a custom setup
 
 # -- Set Secret object containing the keyring information: KEYRING_NAME, KEYRING_PASSWORD, KEYRING_MNEMONIC and ETHEREUM_ENDPOINT
 secret: "NAME_OF_THE_SECRET"

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -17,6 +17,7 @@ env:
   MEZOD_CUSTOM_CONF_APP_TOML: /config/app.toml.txt
   MEZOD_CUSTOM_CONF_CLIENT_TOML: /config/client.toml.txt
   MEZOD_CUSTOM_CONF_CONFIG_TOML: /config/config.toml.txt
+  MEZOD_P2P_PORT: 26656 # Default. It should be changed in case of a custom setup
 
 # -- Set Secret object containing the keyring information: KEYRING_NAME, KEYRING_PASSWORD, KEYRING_MNEMONIC and ETHEREUM_ENDPOINT
 secret: "NAME_OF_THE_SECRET"

--- a/native/README.md
+++ b/native/README.md
@@ -47,6 +47,7 @@ fill the environment file (in case of testnet it's `testnet.env`).
 (required for the sidecar to run)
 - `MEZOD_PUBLIC_IP` - public IP address of the validator
 - `MEZOD_DOWNLOAD_LINK` - link to a public repository hosting a `tar.gz` file with mezo binary
+- `MEZOD_P2P_PORT` - the port for the P2P connection. Default is `26656`
 
 ### 2. Prepare installation script to run
 

--- a/native/README.md
+++ b/native/README.md
@@ -47,7 +47,7 @@ fill the environment file (in case of testnet it's `testnet.env`).
 (required for the sidecar to run)
 - `MEZOD_PUBLIC_IP` - public IP address of the validator
 - `MEZOD_DOWNLOAD_LINK` - link to a public repository hosting a `tar.gz` file with mezo binary
-- `MEZOD_P2P_PORT` - the port for the P2P connection. Default is `26656`
+- `MEZOD_PORT_P2P` - the port for the P2P connection. Default is `26656`
 
 ### 2. Prepare installation script to run
 

--- a/native/testnet.env.example
+++ b/native/testnet.env.example
@@ -33,4 +33,4 @@ export MEZOD_DOWNLOAD_LINK="<download_link_for_mezod_package>"
 
 ### P2P Config ###
 # Default. It should be changed in case of a custom setup
-export MEZOD_P2P_PORT=26656
+export MEZOD_PORT_P2P=26656

--- a/native/testnet.env.example
+++ b/native/testnet.env.example
@@ -30,3 +30,7 @@ export MEZOD_PUBLIC_IP="<your_public_ip>"
 ### Download Link ###
 # Appropriate link for the mezo package (right now it should be a google artifact registry repository link)
 export MEZOD_DOWNLOAD_LINK="<download_link_for_mezod_package>"
+
+### P2P Config ###
+# Default. It should be changed in case of a custom setup
+export MEZOD_P2P_PORT=26656

--- a/native/v-kit.sh
+++ b/native/v-kit.sh
@@ -171,11 +171,11 @@ configure_mezo() {
     ${MEZO_EXEC} toml set \
         ${config_file} \
         -v moniker="${MEZOD_MONIKER}" \
-        -v p2p.laddr="tcp://0.0.0.0:26656" \
+        -v p2p.laddr="tcp://0.0.0.0:${MEZOD_P2P_PORT}" \
         -v rpc.laddr="tcp://0.0.0.0:26657" \
         -v instrumentation.prometheus=true \
         -v instrumentation.prometheus_listen_addr="0.0.0.0:26660" \
-        -v p2p.external_address="${MEZOD_PUBLIC_IP}:26656" \
+        -v p2p.external_address="${MEZOD_PUBLIC_IP}:${MEZOD_P2P_PORT}" \
         -v consensus.timeout_propose="30s" \
         -v consensus.timeout_propose_delta="5s" \
         -v consensus.timeout_prevote="10s" \

--- a/native/v-kit.sh
+++ b/native/v-kit.sh
@@ -171,11 +171,11 @@ configure_mezo() {
     ${MEZO_EXEC} toml set \
         ${config_file} \
         -v moniker="${MEZOD_MONIKER}" \
-        -v p2p.laddr="tcp://0.0.0.0:${MEZOD_P2P_PORT}" \
+        -v p2p.laddr="tcp://0.0.0.0:${MEZOD_PORT_P2P}" \
         -v rpc.laddr="tcp://0.0.0.0:26657" \
         -v instrumentation.prometheus=true \
         -v instrumentation.prometheus_listen_addr="0.0.0.0:26660" \
-        -v p2p.external_address="${MEZOD_PUBLIC_IP}:${MEZOD_P2P_PORT}" \
+        -v p2p.external_address="${MEZOD_PUBLIC_IP}:${MEZOD_PORT_P2P}" \
         -v consensus.timeout_propose="30s" \
         -v consensus.timeout_propose_delta="5s" \
         -v consensus.timeout_prevote="10s" \


### PR DESCRIPTION
Depends on https://github.com/mezo-org/mezod/pull/357
Closes: #24 

Refs https://linear.app/thesis-co/issue/ENG-415/support-custom-p2p-ports-in-the-validator-kit

~~Note. Please do not merge until we have a new image/binary cut from mezod repo. Leaving it as a draft for now.~~ We have a new `[v0.2.0-rc2](https://github.com/mezo-org/mezod/releases/tag/v0.2.0-rc2)` image that contains needed dependency.

Some of the validators might want to set a custom p2p port in their node configs. We need to allow them doing so. Adjusted custom p2p port setup for docker, native and helm-chart approaches.