### PR TITLE
Fix GHA for PRs

### DIFF
--- a/.github/workflows/checks-pr.yaml
+++ b/.github/workflows/checks-pr.yaml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "helm-chart/**"
 
 jobs:
   helm-chart-release-version:


### PR DESCRIPTION
Check for Helm chart must be running only when concern to helm charts folder.