### PR TITLE
Bump and fix chart

### DIFF
--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 0.0.6
-appVersion: v0.2.0-rc1
+version: 0.0.7
+appVersion: v0.2.0-rc2

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -42,7 +42,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | string | `"us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"` |  |
-| tag | string | `"v0.2.0-rc1"` |  |
+| tag | string | `"v0.2.0-rc2"` |  |
 | env.NETWORK | string | `"testnet"` | Select the network to connect to |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |
 | env.MEZOD_CHAIN_ID | string | `"mezo_31611-1"` | Set the chain ID (mezo_31611-1 is the testnet) |

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -35,7 +35,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![AppVersion: v0.2.0-rc1](https://img.shields.io/badge/AppVersion-v0.2.0--rc1-informational?style=flat-square)
+![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![AppVersion: v0.2.0-rc2](https://img.shields.io/badge/AppVersion-v0.2.0--rc2-informational?style=flat-square)
 
 ## Values
 

--- a/helm-chart/mezod/templates/statefulset.yaml
+++ b/helm-chart/mezod/templates/statefulset.yaml
@@ -69,7 +69,7 @@ spec:
           env:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
-              value: {{ $value }}
+              value: {{ $value | quote }}
             {{- end }}
             - name: KEYRING_NAME
               valueFrom:

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,5 @@
 image: "us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"
-tag: "v0.2.0-rc1"
+tag: "v0.2.0-rc2"
 
 env:
   # -- Select the network to connect to


### PR DESCRIPTION
Changes

- bump Docker image and Helm chart version
- Fix for environment variables. They must be strings, because Helm fails. `| quote` will do `"123"` from `123`.