### PR TITLE
Adjust V-Kit to the Connect oracle changes

### DIFF
--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 0.0.7
-appVersion: v0.2.0-rc2
+version: 0.0.9
+appVersion: v0.3.0-rc0

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -35,20 +35,21 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![AppVersion: v0.2.0-rc2](https://img.shields.io/badge/AppVersion-v0.2.0--rc2-informational?style=flat-square)
+![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square) ![AppVersion: v0.3.0-rc0](https://img.shields.io/badge/AppVersion-v0.3.0--rc0-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | string | `"us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"` |  |
-| tag | string | `"v0.2.0-rc2"` |  |
+| tag | string | `"v0.3.0-rc0"` |  |
 | env.NETWORK | string | `"testnet"` | Select the network to connect to |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |
 | env.MEZOD_CHAIN_ID | string | `"mezo_31611-1"` | Set the chain ID (mezo_31611-1 is the testnet) |
 | env.MEZOD_HOME | string | `"/var/mezod"` |  |
 | env.MEZOD_MONIKER | string | `"CHANGE_ME"` | Set the moniker (name of the validator) |
 | env.MEZOD_ETHEREUM_SIDECAR_SERVER | string | `"localhost:7500"` |  |
+| env.MEZOD_ORACLE_ORACLE_ADDRESS | string | `"localhost:8080"` |  |
 | env.MEZOD_LOG_LEVEL | string | `"info"` |  |
 | env.MEZOD_LOG_FORMAT | string | `"json"` |  |
 | env.MEZOD_CUSTOM_CONF_APP_TOML | string | `"/config/app.toml.txt"` |  |

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,5 @@
 image: "us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"
-tag: "v0.2.0-rc2"
+tag: "v0.3.0-rc0"
 
 env:
   # -- Select the network to connect to
@@ -12,6 +12,7 @@ env:
   # -- Set the moniker (name of the validator)
   MEZOD_MONIKER: "CHANGE_ME"
   MEZOD_ETHEREUM_SIDECAR_SERVER: "localhost:7500" # it's in the same Pod
+  MEZOD_ORACLE_ORACLE_ADDRESS: "localhost:8080" # it's in the same Pod
   MEZOD_LOG_LEVEL: info
   MEZOD_LOG_FORMAT: json # json|plain
   MEZOD_CUSTOM_CONF_APP_TOML: /config/app.toml.txt

--- a/native/testnet.env.example
+++ b/native/testnet.env.example
@@ -21,6 +21,8 @@ export MEZOD_KEY_NAME="key0"
 export MEZOD_LOGLEVEL="info"
 
 export CONNECT_SIDECAR_PORT=8080
+export MEZOD_ORACLE_ORACLE_ADDRESS="127.0.0.1:$CONNECT_SIDECAR_PORT"
+export MEZOD_ORACLE_ENABLED="true"
 
 ### Setup ###
 # Version of mezod release you want to install


### PR DESCRIPTION
We are about to roll out the Connect oracle on Mezo testnet. We need to ensure existing validators can seamlessly connect with their Connect sidecars once the upgrade happens.

Pull request https://github.com/mezo-org/mezod/pull/359 introduces the following on the `mezod` side:
- The `init` command now adds the oracle-specific config to `app.toml`.
- The `start` command exposes oracle-specific flags (`--oracle.*` family) with default values.
- The `customize_configuration` of the `entrypoint.sh` enables the oracle by default and allows setting its address using the `MEZOD_ORACLE_ORACLE_ADDRESS` env (naming adjusted to the `app.toml` param according to Vyper's convention). If this env is not set, the default value of `connect-sidecar:8080` is used.

To make everything work, we are introducing some adjustments to the following variants of the V-Kit:
- Helm: We are setting the `MEZOD_ORACLE_ORACLE_ADDRESS: "localhost:8080"` env. This is necessary to pass the correct address to the `mezod` entrypoint. Otherwise, `connect-sidecar:8080` will be used by default which is wrong in the Kubernetes context
- Native: We are exporting `MEZOD_ORACLE_ORACLE_ADDRESS` and `MEZOD_ORACLE_ENABLED` with appropriate values. This is not strictly needed due to `mezod` default values of the `--oracle.*` flags but, we are doing it for consistency and because the Connect sidecar port is configurable in this variant of the V-Kit

Docker variant doesn't have to be adjusted because it performs `init` on restart. That will add the oracle-specific config to `app.toml` and leverage the default oracle address set in the entrypoint which is correct in the context of Docker.