### PR TITLE
Bump mezod to v0.2.0-rc3 in the Helm chart

### DIFF
--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 0.0.7
-appVersion: v0.2.0-rc2
+version: 0.0.8
+appVersion: v0.2.0-rc3

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -35,14 +35,14 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![AppVersion: v0.2.0-rc2](https://img.shields.io/badge/AppVersion-v0.2.0--rc2-informational?style=flat-square)
+![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![AppVersion: v0.2.0-rc3](https://img.shields.io/badge/AppVersion-v0.2.0--rc3-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | string | `"us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"` |  |
-| tag | string | `"v0.2.0-rc2"` |  |
+| tag | string | `"v0.2.0-rc3"` |  |
 | env.NETWORK | string | `"testnet"` | Select the network to connect to |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |
 | env.MEZOD_CHAIN_ID | string | `"mezo_31611-1"` | Set the chain ID (mezo_31611-1 is the testnet) |

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,5 @@
 image: "us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"
-tag: "v0.2.0-rc2"
+tag: "v0.2.0-rc3"
 
 env:
   # -- Select the network to connect to


### PR DESCRIPTION
We released mezod v0.2.0-rc3, and we need to upgrade our Mezo testnet validators to that version. As they already use the V-Kit Helm chart, we first need to bump the version here.