### PR TITLE
Parametrize image pull policy

### DIFF
--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 0.0.9
+version: 0.0.10
 appVersion: v0.3.0-rc0

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -35,7 +35,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square) ![AppVersion: v0.3.0-rc0](https://img.shields.io/badge/AppVersion-v0.3.0--rc0-informational?style=flat-square)
+![Version: 0.0.10](https://img.shields.io/badge/Version-0.0.10-informational?style=flat-square) ![AppVersion: v0.3.0-rc0](https://img.shields.io/badge/AppVersion-v0.3.0--rc0-informational?style=flat-square)
 
 ## Values
 
@@ -43,6 +43,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 |-----|------|---------|-------------|
 | image | string | `"us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"` |  |
 | tag | string | `"v0.3.0-rc0"` |  |
+| imagePullPolicy | string | `"Always"` |  |
 | env.NETWORK | string | `"testnet"` | Select the network to connect to |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |
 | env.MEZOD_CHAIN_ID | string | `"mezo_31611-1"` | Set the chain ID (mezo_31611-1 is the testnet) |
@@ -90,5 +91,6 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 | labels | object | `{}` |  |
 | connectSidecar.image | string | `"ghcr.io/skip-mev/connect-sidecar"` |  |
 | connectSidecar.tag | string | `"v2.1.2"` |  |
+| connectSidecar.imagePullPolicy | string | `"Always"` |  |
 | connectSidecar.ports.http | int | `8080` |  |
 

--- a/helm-chart/mezod/templates/statefulset.yaml
+++ b/helm-chart/mezod/templates/statefulset.yaml
@@ -50,7 +50,7 @@ spec:
         #
         - name: mezod
           image: "{{ .Values.image }}:{{ .Values.tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- if .Values.maintenanceMode }}
           args:
             - /bin/sh
@@ -116,7 +116,7 @@ spec:
         #
         - name: ethereum-sidecar
           image: "{{ .Values.image }}:{{ .Values.tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           command:
             - mezod
             - ethereum-sidecar
@@ -150,7 +150,7 @@ spec:
         #
         - name: connect-sidecar
           image: "{{ .Values.connectSidecar.image }}:{{ .Values.connectSidecar.tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.connectSidecar.imagePullPolicy }}
           command:
             - connect
             - --disable-telemetry

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,6 @@
 image: "us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"
 tag: "v0.3.0-rc0"
+imagePullPolicy: Always
 
 env:
   # -- Select the network to connect to
@@ -91,5 +92,6 @@ connectSidecar:
   # Dockerfile: https://github.com/skip-mev/connect/blob/main/contrib/images/connect.sidecar.prod.Dockerfile
   image: "ghcr.io/skip-mev/connect-sidecar"
   tag: "v2.1.2"
+  imagePullPolicy: Always
   ports:
     http: 8080


### PR DESCRIPTION
Here we parametrize the `imagePullPolicy` for `mezod` and Connect Docker images. There are some use cases where this setting is beneficial. We are also setting the `Always` policy as default to make sure containers always use the freshest image.