### PR TITLE
Set pruning parameter in a correct way

### DIFF
--- a/native/v-kit.sh
+++ b/native/v-kit.sh
@@ -194,7 +194,7 @@ configure_mezo() {
         -v json-rpc.api="eth,txpool,personal,net,debug,web3" \
         -v json-rpc.ws-address="0.0.0.0:8546" \
         -v json-rpc.metrics-address="0.0.0.0:6065" \
-        -v "pruning=nothing"
+        -v pruning="nothing"
 
 }
 


### PR DESCRIPTION
This is a small fix for setting pruning parameter in `mezod toml set` section. From `-v "pruning=nothing"` to `-v pruning="nothing"`.