### PR TITLE
Bump mezod and Ethereum sidecar to v0.3.0-rc2

### DIFF
--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 1.0.0
-appVersion: v0.3.0-rc0
+version: 1.0.1
+appVersion: v0.3.0-rc2

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -35,14 +35,14 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: v0.3.0-rc0](https://img.shields.io/badge/AppVersion-v0.3.0--rc0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: v0.3.0-rc2](https://img.shields.io/badge/AppVersion-v0.3.0--rc2-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | string | `"us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"` |  |
-| tag | string | `"v0.3.0-rc0"` |  |
+| tag | string | `"v0.3.0-rc2"` |  |
 | imagePullPolicy | string | `"Always"` |  |
 | env.NETWORK | string | `"testnet"` | Select the network to connect to |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,5 @@
 image: "us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"
-tag: "v0.3.0-rc0"
+tag: "v0.3.0-rc2"
 imagePullPolicy: Always
 
 env:


### PR DESCRIPTION
Here we bump the `mezod` image to the latest version to include recent improvements. We also bump the chart version to v1.0.1