### PR TITLE
Bump mezod to v0.4.0-rc0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ of `mezod` and upgrade along the way to handle on-chain upgrades properly.
 
 Version ordering for Mezo Matsnet testnet:
 - `v0.2.0-rc3`: initial version from genesis to block 1093500
-- `v0.3.0-rc*`: from block 1093500 to the current chain tip (pick the latest `-rc*`)
+- `v0.3.0-rc3`: from block 1093500 to block 1745000
+- `v0.4.0-rc*`: from block 1745000 to the current chain tip (pick the latest `-rc*`)
 
 ### State sync from snapshot
 

--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 1.0.2
-appVersion: v0.3.0-rc2
+version: 1.1.0
+appVersion: v0.4.0-rc0

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -35,14 +35,14 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: v0.3.0-rc2](https://img.shields.io/badge/AppVersion-v0.3.0--rc2-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: v0.4.0-rc0](https://img.shields.io/badge/AppVersion-v0.4.0--rc0-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | string | `"us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"` |  |
-| tag | string | `"v0.3.0-rc2"` |  |
+| tag | string | `"v0.4.0-rc0"` |  |
 | imagePullPolicy | string | `"Always"` |  |
 | env.NETWORK | string | `"testnet"` | Select the network to connect to |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,5 @@
 image: "us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"
-tag: "v0.3.0-rc2"
+tag: "v0.4.0-rc0"
 imagePullPolicy: Always
 
 env:


### PR DESCRIPTION
Here we bump the `mezod` version to `v0.4.0-rc0` and release a new version of the Helm chart.