### PR TITLE
Updated docs for launching Ethereum sidecar

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -82,7 +82,8 @@ cp testnet.env.example testnet.env
   ```
 
 * `MEZOD_MONIKER` - the name of the validator
-* `MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS` - the address of the Ethereum node
+* `MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS` - the address of the Ethereum node.
+The URL must be WebSocket, i.e. start with `wss://` (recommended) or `ws://`.
 * `PUBLIC_IP` - the public IP address of the validator
 * `MEZOD_PORT_P2P` - the port for the P2P connection. Default is `26656`
 

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -22,6 +22,8 @@ password="$(openssl rand -hex 32)"
 # Get the latest version of $DOCKER_IMAGE from registry
 mnemonic="$(docker run --rm -it --platform linux/amd64 --entrypoint="" <DOCKER_IMAGE> mezod keys mnemonic)"
 
+# Set secret values. The ETHEREUM_ENDPOINT URL must be WebSocket, i.e. start
+# with `wss://` (recommended) or `ws://`.
 kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
   --from-literal=KEYRING_NAME="$name" \
   --from-literal=KEYRING_PASSWORD="$password" \

--- a/manual/README.md
+++ b/manual/README.md
@@ -139,8 +139,10 @@ The following setup assumes a Unix-like environment.
     mezod ethereum-sidecar \
      --ethereum-sidecar.server.ethereum-node-address=wss://eth-sepolia.g.alchemy.com/v2/<redacted>
     ```
-    The above command assumes you are using the Alchemy provider. Adjust the command
-    according to your setup if needed. For further configuration options, see
+    The above command assumes you are using the Alchemy provider. Only the WebSocket
+    protocol is supported for the Ethereum node address, i.e. the URL must start
+    with `wss://` (recommended) or `ws://`. Adjust the command according to your
+    setup if needed. For further configuration options, see
     `mezod ethereum-sidecar --help`.
     <br/><br/>
     **If you build `mezod` from source, remember about running `make bindings`

--- a/native/README.md
+++ b/native/README.md
@@ -45,7 +45,7 @@ fill the environment file (in case of testnet it's `testnet.env`).
 (to generate best possible password, you can use `openssl rand -hex 32` command)
 - `MEZOD_KEYRING_MNEMONIC` - mnemonic for keyring (the best option is to generate it using `v-kit.sh`)
 - `MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS` - address for the Ethereum node
-(required for the sidecar to run)
+(required for the sidecar to run). The URL must be WebSocket, i.e. start with `wss://` (recommended) or `ws://`.
 - `MEZOD_PUBLIC_IP` - public IP address of the validator
 - `MEZOD_DOWNLOAD_LINK` - link to a public repository hosting a `tar.gz` file with mezo binary
 - `MEZOD_PORT_P2P` - the port for the P2P connection. Default is `26656`


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-17/enforce-websocket-rpc-in-the-ethereum-sidecar

This PR updates documents describing launching Ethereum sidecar.
When launching Ethereum sidecar we must use a WebSocket URL for the `--ethereum-sidecar.server.ethereum-node-address` option (e.g.: `wss://eth-sepolia.g.alchemy.com/v2/<your-key>`). This will soon be enforced by a check in Ethereum sidecar.