### PR TITLE
Updated Helm docs

### DIFF
--- a/helm-chart/mezod/README.md.gotmpl
+++ b/helm-chart/mezod/README.md.gotmpl
@@ -22,6 +22,8 @@ password="$(openssl rand -hex 32)"
 # Get the latest version of $DOCKER_IMAGE from registry
 mnemonic="$(docker run --rm -it --platform linux/amd64 --entrypoint="" <DOCKER_IMAGE> mezod keys mnemonic)"
 
+# Set secret values. The ETHEREUM_ENDPOINT URL must be WebSocket, i.e. start
+# with `wss://` (recommended) or `ws://`.
 kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
   --from-literal=KEYRING_NAME="$name" \
   --from-literal=KEYRING_PASSWORD="$password" \


### PR DESCRIPTION
This PR is a follow-up to: https://github.com/mezo-org/validator-kit/pull/48 which introduced a CI error.
We need to update the Helm chart README.