### PR TITLE
Update version ordering guide for block sync from genesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ of `mezod` and upgrade along the way to handle on-chain upgrades properly.
 Version ordering for Mezo Matsnet testnet:
 - `v0.2.0-rc3`: initial version from genesis to block 1093500
 - `v0.3.0-rc3`: from block 1093500 to block 1745000
-- `v0.4.0-rc*`: from block 1745000 to the current chain tip (pick the latest `-rc*`)
+- `v0.4.0-rc1`: from block 1745000 to block 2213000
+- `v0.5.0-rc*`: from block 2213000 to the current chain tip (pick the latest `-rc*`)
 
 ### State sync from snapshot
 


### PR DESCRIPTION
Here we add the missing info about the recent v0.5.0 fork.