### PR TITLE
Fix last `v0.6.0-rc*` version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Version ordering for Mezo Matsnet testnet:
 - `v0.3.0-rc3`: from block 1093500 to block 1745000
 - `v0.4.0-rc1`: from block 1745000 to block 2213000
 - `v0.5.0-rc1`: from block 2213000 to block 2563000
-- `v0.6.0-rc1`: from block 2563000 to block 3078794
+- `v0.6.0-rc2`: from block 2563000 to block 3078794
 - `v0.7.0-rc*`: from block 3078794 to the current chain tip (pick the latest `-rc*`)
 
 ### State sync from snapshot


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-382/the-v070-matsnet-fork

[The last version of this release line is `v0.6.0-rc2`](https://github.com/mezo-org/mezod/tags) and it should be used during the block sync process. By mistake, we put `v0.6.0-rc1` here so we are changing it.