### PR TITLE
Bumping helm chart version preping for v1.0.0-rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Version ordering for Mezo Matsnet testnet:
 - `v0.5.0-rc1`: from block 2213000 to block 2563000
 - `v0.6.0-rc2`: from block 2563000 to block 3078794
 - `v0.7.0-rc0`: from block 3078794 to block 3569000
-- `v1.0.0-rc*`: from block 3569000 to the current chain tip (pick the latest `-rc*`)
+- `v1.0.0-rc0`: from block 3569000 to block 3712500
+- `v1.0.0-rc*`: from block 3712500 to the current chain tip (pick the latest `-rc*`)
 
 ### State sync from snapshot
 

--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 1.5.0
-appVersion: v1.0.0-rc0
+version: 1.6.0
+appVersion: v1.0.0-rc1

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -37,14 +37,14 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![AppVersion: v1.0.0-rc0](https://img.shields.io/badge/AppVersion-v1.0.0--rc0-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![AppVersion: v1.0.0-rc1](https://img.shields.io/badge/AppVersion-v1.0.0--rc1-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | string | `"us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"` |  |
-| tag | string | `"v1.0.0-rc0"` |  |
+| tag | string | `"v1.0.0-rc1"` |  |
 | imagePullPolicy | string | `"Always"` |  |
 | env.NETWORK | string | `"testnet"` | Select the network to connect to |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,5 @@
 image: "us-central1-docker.pkg.dev/mezo-test-420708/mezo-staging-docker-public/mezod"
-tag: "v1.0.0-rc0"
+tag: "v1.0.0-rc1"
 imagePullPolicy: Always
 
 env:


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-701/the-v100-rc1-matsnet-upgrade

Here we bump the `mezod` version to `v1.0.0-rc1` and release a new version of the Helm chart.