### PR TITLE
Add validator/seed/rpc/rpc-archive node types support for helm chart

### DIFF
--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -45,6 +45,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 | image | string | `"mezo/mezod"` |  |
 | tag | string | `"v1.0.0"` |  |
 | imagePullPolicy | string | `"Always"` |  |
+| nodeType | string | `"validator"` | Select whether you want to run a validator/seed node/RPC node ("validator"/"seed"/"rpc"/"rpc-archive") |
 | env.NETWORK | string | `"mainnet"` | Select the network to connect to (mainnet or testnet) |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |
 | env.MEZOD_CHAIN_ID | string | `"mezo_31612-1"` | Set the chain ID (mezo_31612-1 is mainnet, mezo_31611-1 is testnet) |

--- a/helm-chart/mezod/templates/configmap.yaml
+++ b/helm-chart/mezod/templates/configmap.yaml
@@ -1,56 +1,37 @@
+{{- if or .Values.customConfigs.enabled 
+  (or 
+    (eq .Values.nodeType "seed")
+    (eq .Values.nodeType "rpc")
+  ) 
+}}
 ---
-{{- if .Values.customConfigs.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "custom-configs-{{ include "this.name" . }}"
   labels:
+    node_type: {{ .Values.nodeType }}
     {{- include "this.labels" . | nindent 4 }}
     {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  annotations:
-    mezo.org/node_type: {{ .Values.nodeType | quote }}
 data:
-  {{- if .Values.customConfigs.appTomlTxt }}
   app.toml.txt: |
+  {{- if .Values.customConfigs.appTomlTxt }}
     {{- .Values.customConfigs.appTomlTxt | nindent 4 }}
+  {{- end }}
   {{- if eq .Values.nodeType "rpc-archive" }}
     pruning=nothing
-  {{- end }}
   {{- end }}
   {{- if .Values.customConfigs.clientTomlTxt }}
   client.toml.txt: |
     {{- .Values.customConfigs.clientTomlTxt | nindent 4 }}
   {{- end }}
-  {{- if .Values.customConfigs.configTomlTxt }}
   config.toml.txt: |
+  {{- if .Values.customConfigs.configTomlTxt }}
     {{- .Values.customConfigs.configTomlTxt | nindent 4 }}
+  {{- end }}
   {{- if eq .Values.nodeType "seed" }}
     p2p.seed_mode=true
   {{- end }}
-  {{- end }}
-{{- else }}
-{{ if or (eq .Values.nodeType "seed") (eq .Values.nodeType "rpc-archive") }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: "custom-configs-{{ include "this.name" . }}"
-  labels:
-    {{- include "this.labels" . | nindent 4 }}
-    {{- with .Values.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-  annotations:
-    mezo.org/node_type: {{ .Values.nodeType | quote }}
-data:
-{{- if eq .Values.nodeType "rpc-archive" }}
-  app.toml.txt: |
-    pruning=nothing
-{{- end }}
-{{- if eq .Values.nodeType "seed" }}
-  config.toml.txt: 
-    p2p.seed_mode=true
-{{- end }}
-{{- end }}
 {{- end }}

--- a/helm-chart/mezod/templates/configmap.yaml
+++ b/helm-chart/mezod/templates/configmap.yaml
@@ -13,6 +13,9 @@ data:
   {{- if .Values.customConfigs.appTomlTxt }}
   app.toml.txt: |
     {{- .Values.customConfigs.appTomlTxt | nindent 4 }}
+  {{- if eq .Values.mode "rpc-archive" }}
+    pruning=nothing
+  {{- end }}
   {{- end }}
   {{- if .Values.customConfigs.clientTomlTxt }}
   client.toml.txt: |
@@ -21,5 +24,29 @@ data:
   {{- if .Values.customConfigs.configTomlTxt }}
   config.toml.txt: |
     {{- .Values.customConfigs.configTomlTxt | nindent 4 }}
+  {{- if eq .Values.mode "seed" }}
+    p2p.seed_mode=true
   {{- end }}
+  {{- end }}
+{{- else }}
+{{ if or (eq .Values.mode "seed") (eq .Values.mode "rpc-archive") }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "custom-configs-{{ include "this.name" . }}"
+  labels:
+    {{- include "this.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+{{- if eq .Values.mode "rpc-archive" }}
+  app.toml.txt: |
+    pruning=nothing
+{{- end }}
+{{- if eq .Values.mode "seed" }}
+  config.toml.txt: 
+    p2p.seed_mode=true
+{{- end }}
+{{- end }}
 {{- end }}

--- a/helm-chart/mezod/templates/configmap.yaml
+++ b/helm-chart/mezod/templates/configmap.yaml
@@ -9,11 +9,13 @@ metadata:
     {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  annotations:
+    mezo.org/node_type: {{ .Values.nodeType | quote }}
 data:
   {{- if .Values.customConfigs.appTomlTxt }}
   app.toml.txt: |
     {{- .Values.customConfigs.appTomlTxt | nindent 4 }}
-  {{- if eq .Values.mode "rpc-archive" }}
+  {{- if eq .Values.nodeType "rpc-archive" }}
     pruning=nothing
   {{- end }}
   {{- end }}
@@ -24,12 +26,12 @@ data:
   {{- if .Values.customConfigs.configTomlTxt }}
   config.toml.txt: |
     {{- .Values.customConfigs.configTomlTxt | nindent 4 }}
-  {{- if eq .Values.mode "seed" }}
+  {{- if eq .Values.nodeType "seed" }}
     p2p.seed_mode=true
   {{- end }}
   {{- end }}
 {{- else }}
-{{ if or (eq .Values.mode "seed") (eq .Values.mode "rpc-archive") }}
+{{ if or (eq .Values.nodeType "seed") (eq .Values.nodeType "rpc-archive") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -39,12 +41,14 @@ metadata:
     {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  annotations:
+    mezo.org/node_type: {{ .Values.nodeType | quote }}
 data:
-{{- if eq .Values.mode "rpc-archive" }}
+{{- if eq .Values.nodeType "rpc-archive" }}
   app.toml.txt: |
     pruning=nothing
 {{- end }}
-{{- if eq .Values.mode "seed" }}
+{{- if eq .Values.nodeType "seed" }}
   config.toml.txt: 
     p2p.seed_mode=true
 {{- end }}

--- a/helm-chart/mezod/templates/service-private.yaml
+++ b/helm-chart/mezod/templates/service-private.yaml
@@ -5,12 +5,11 @@ kind: Service
 metadata:
   name: "private-{{ include "this.name" . }}"
   labels:
+    node_type: {{ .Values.nodeType }}
     {{- include "this.labels" . | nindent 4 }}
     {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  annotations:
-    mezo.org/node_type: {{ .Values.nodeType | quote }}
 spec:
   type: ClusterIP
   selector:

--- a/helm-chart/mezod/templates/service-private.yaml
+++ b/helm-chart/mezod/templates/service-private.yaml
@@ -9,6 +9,8 @@ metadata:
     {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  annotations:
+    mezo.org/node_type: {{ .Values.nodeType | quote }}
 spec:
   type: ClusterIP
   selector:

--- a/helm-chart/mezod/templates/service-public.yaml
+++ b/helm-chart/mezod/templates/service-public.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- with .Values.service.public.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    mezo.org/node_type: {{ .Values.nodeType | quote }}
 spec:
   type: {{ .Values.service.public.type | quote }}
   {{- if .Values.service.public.loadBalancerIP }}

--- a/helm-chart/mezod/templates/service-public.yaml
+++ b/helm-chart/mezod/templates/service-public.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   name: "public-{{ include "this.name" . }}"
   labels:
+    node_type: {{ .Values.nodeType }}
     {{- include "this.labels" . | nindent 4 }}
     {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
@@ -13,8 +14,7 @@ metadata:
     {{- with .Values.service.public.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    mezo.org/node_type: {{ .Values.nodeType | quote }}
-spec:
+ spec:
   type: {{ .Values.service.public.type | quote }}
   {{- if .Values.service.public.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.public.loadBalancerIP | quote }}

--- a/helm-chart/mezod/templates/serviceaccount.yaml
+++ b/helm-chart/mezod/templates/serviceaccount.yaml
@@ -7,4 +7,6 @@ metadata:
     {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  annotations:
+    mezo.org/node_type: {{ .Values.nodeType | quote }}
 automountServiceAccountToken: false

--- a/helm-chart/mezod/templates/serviceaccount.yaml
+++ b/helm-chart/mezod/templates/serviceaccount.yaml
@@ -3,10 +3,9 @@ kind: ServiceAccount
 metadata:
   name: {{ include "this.name" . | quote }}
   labels:
+    node_type: {{ .Values.nodeType }}
     {{- include "this.labels" . | nindent 4 }}
     {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  annotations:
-    mezo.org/node_type: {{ .Values.nodeType | quote }}
 automountServiceAccountToken: false

--- a/helm-chart/mezod/templates/statefulset.yaml
+++ b/helm-chart/mezod/templates/statefulset.yaml
@@ -3,12 +3,11 @@ kind: StatefulSet
 metadata:
   name: {{ include "this.name" . | quote }}
   labels:
+    node_type: {{ .Values.nodeType }}
     {{- include "this.labels" . | nindent 4 }}
     {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  annotations:
-    mezo.org/node_type: {{ .Values.nodeType | quote }}
 spec:
   replicas: 1
   serviceName: {{ include "this.name" . | quote }}

--- a/helm-chart/mezod/templates/statefulset.yaml
+++ b/helm-chart/mezod/templates/statefulset.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  annotations:
+    mezo.org/node_type: {{ .Values.nodeType | quote }}
 spec:
   replicas: 1
   serviceName: {{ include "this.name" . | quote }}

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -3,7 +3,7 @@ tag: "v1.0.0"
 imagePullPolicy: Always
 
 # -- Select whether you want to run a validator/seed node/RPC node ("validator"/"seed"/"rpc"/"rpc-archive")
-mode: "validator"
+nodeType: "validator"
 
 env:
   # -- Select the network to connect to (mainnet or testnet)

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -83,13 +83,13 @@ service:
 
 customConfigs:
    # -- Optional: Load custom configuration from the files
-  enabled: true
+  enabled: false
   # As content of the files, you can use the following format:
   # path.to.toml.key=value
   # anotherKey=anotherValue
-  appTomlTxt: "asdf=asdf"
-  clientTomlTxt: "asdf=asdf"
-  configTomlTxt: "asdffff=fff"
+  appTomlTxt: ""
+  clientTomlTxt: ""
+  configTomlTxt: ""
 
 # -- Run shell in the container instead of the mezod process
 maintenanceMode: false

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -2,6 +2,9 @@ image: "mezo/mezod"
 tag: "v1.0.0"
 imagePullPolicy: Always
 
+# -- Select whether you want to run a validator/seed node/RPC node ("validator"/"seed"/"rpc"/"rpc-archive")
+mode: "validator"
+
 env:
   # -- Select the network to connect to (mainnet or testnet)
   NETWORK: mainnet
@@ -57,6 +60,10 @@ service:
     loadBalancerIP: ""
     allocateLoadBalancerNodePorts: false
     # Name of the ports must use kebab-case
+    # External ports required to be exposed (absolute minimum):
+    # - RPC Node: p2p, json-rpc, json-rpc-ws, rpc
+    # - Seed Node: p2p
+    # - Validator Node: p2p
     ports:
       p2p: 26656
       rpc: 26657

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -83,13 +83,13 @@ service:
 
 customConfigs:
    # -- Optional: Load custom configuration from the files
-  enabled: false
+  enabled: true
   # As content of the files, you can use the following format:
   # path.to.toml.key=value
   # anotherKey=anotherValue
-  appTomlTxt: ""
-  clientTomlTxt: ""
-  configTomlTxt: ""
+  appTomlTxt: "asdf=asdf"
+  clientTomlTxt: "asdf=asdf"
+  configTomlTxt: "asdffff=fff"
 
 # -- Run shell in the container instead of the mezod process
 maintenanceMode: false


### PR DESCRIPTION
Add support for changing the Mezo node type via `customConfigs`.

 This change aims to facilitate setting the node types to:
- `validator`
- `rpc` - same as validator (option exists only for labeling the node)
- `rpc-archive` - adds `pruning=nothing` option
- `seed` - adds `p2p.seed_mode=true` option

Moreover, i added annotating the kubernetes resource based on the node type so nodes could be easily distinguished when having multiple types in the same cluster.