### PR TITLE
Prefer default path for configuration files

### DIFF
--- a/docker-monitoring/monitoring.env.template
+++ b/docker-monitoring/monitoring.env.template
@@ -1,5 +1,8 @@
-CONFIG_PATH="./my-configs"
 NETWORK=testnet
 DOMAIN="<domain>"
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD="<good generated password>"
+
+# Uncomment to customize configuration
+# More details in README.md
+#CONFIG_PATH="./my-configs"


### PR DESCRIPTION
This pull request makes a minor update to the `docker-monitoring/monitoring.env.template` file to improve clarity and provide additional guidance for customization.

* Disabled CONFIG_PATH variable in `docker-monitoring/monitoring.env.template` to prefer default configuration path (`compose.yaml` uses `${CONFIG_PATH:-./configs}`)
* Added comments to explain how to customize the `CONFIG_PATH` variable and included a reference to the `README.md` for more details.