### PR TITLE
Bump mezod to v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ of `mezod` and upgrade along the way to handle on-chain upgrades properly.
 
 #### Version ordering for Mezo Mainnet
 
-- `v1.*.*`: from genesis to the current chain tip (pick the latest minor/patch version)
+Asterisk (*) denotes the latest minor/patch version.
+
+- `v1.*.*`: from genesis to block 706500
+- `v2.*.*`: from block 706500 to the current chain tip
 
 ### State sync from snapshot
 

--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 2.0.1
-appVersion: v1.0.0
+version: 3.0.0
+appVersion: v2.0.0

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -36,14 +36,14 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![AppVersion: v2.0.0](https://img.shields.io/badge/AppVersion-v2.0.0-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | string | `"mezo/mezod"` |  |
-| tag | string | `"v1.0.0"` |  |
+| tag | string | `"v2.0.0"` |  |
 | imagePullPolicy | string | `"Always"` |  |
 | env.NETWORK | string | `"mainnet"` | Select the network to connect to (mainnet or testnet) |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,5 @@
 image: "mezo/mezod"
-tag: "v1.0.0"
+tag: "v2.0.0"
 imagePullPolicy: Always
 
 env:


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1126/the-v200-mainnet-upgrade

Here we bump the mezod version to v2.0.0 and release a new version of the Helm chart.