### PR TITLE
Bump mezod to v2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ a long time depending on your network connection and the number of blocks in
 the network. Moreover, you need to start with the initial version
 of `mezod` and upgrade along the way to handle on-chain upgrades properly.
 
-#### Version ordering for Mezo Matsnet testnet
+#### Version ordering for Mezo Testnet
 
 - `v0.2.0-rc3`: initial version from genesis to block 1093500
 - `v0.3.0-rc3`: from block 1093500 to block 1745000
@@ -98,7 +98,8 @@ of `mezod` and upgrade along the way to handle on-chain upgrades properly.
 - `v0.6.0-rc2`: from block 2563000 to block 3078794
 - `v0.7.0-rc0`: from block 3078794 to block 3569000
 - `v1.0.0-rc0`: from block 3569000 to block 3712500
-- `v1.0.0-rc1`: from block 3712500 to the current chain tip
+- `v1.0.0-rc1`: from block 3712500 to block 5559500
+- `v2.0.2`: from block 5559500 to the current chain tip
 
 #### Version ordering for Mezo Mainnet
 

--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 3.0.1
-appVersion: v2.0.1
+version: 3.0.2
+appVersion: v2.0.2

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -36,14 +36,14 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![AppVersion: v2.0.1](https://img.shields.io/badge/AppVersion-v2.0.1-informational?style=flat-square)
+![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![AppVersion: v2.0.2](https://img.shields.io/badge/AppVersion-v2.0.2-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | string | `"mezo/mezod"` |  |
-| tag | string | `"v2.0.1"` |  |
+| tag | string | `"v2.0.2"` |  |
 | imagePullPolicy | string | `"Always"` |  |
 | env.NETWORK | string | `"mainnet"` | Select the network to connect to (mainnet or testnet) |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,5 @@
 image: "mezo/mezod"
-tag: "v2.0.1"
+tag: "v2.0.2"
 imagePullPolicy: Always
 
 env:


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1294/the-v202-mezod-release

Here we bump the mezod version to v2.0.2 and release a new version of the Helm chart.