### PR TITLE
Bump mezod to v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Asterisk (*) denotes the latest minor/patch version.
 Asterisk (*) denotes the latest minor/patch version.
 
 - `v1.*.*`: from genesis to block 706500
-- `v2.*.*`: from block 706500 to the current chain tip
+- `v2.*.*`: from block 706500 to block 1735000
+- `v3.*.*`: from block 1735000 to the current chain tip
 
 ### State sync from snapshot
 

--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 3.0.2
-appVersion: v2.0.2
+version: 4.0.0
+appVersion: v3.0.0

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -36,14 +36,14 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![AppVersion: v2.0.2](https://img.shields.io/badge/AppVersion-v2.0.2-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: v3.0.0](https://img.shields.io/badge/AppVersion-v3.0.0-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | string | `"mezo/mezod"` |  |
-| tag | string | `"v2.0.2"` |  |
+| tag | string | `"v3.0.0"` |  |
 | imagePullPolicy | string | `"Always"` |  |
 | env.NETWORK | string | `"mainnet"` | Select the network to connect to (mainnet or testnet) |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,5 @@
 image: "mezo/mezod"
-tag: "v2.0.2"
+tag: "v3.0.0"
 imagePullPolicy: Always
 
 env:


### PR DESCRIPTION
References: https://linear.app/thesis-co/issue/TET-1300/the-v300-mezod-release-mainnet

Here we bump the mezod version to v3.0.0 and release a new version of the Helm chart.