### PR TITLE
Adjust the V-Kit to Ethereum sidecar changes related to bridge out

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -50,6 +50,9 @@ services:
       - --log_format=json
       - --ethereum-sidecar.server.ethereum-node-address=${MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS}
       - --ethereum-sidecar.server.network=${MEZOD_ETHEREUM_SIDECAR_SERVER_NETWORK}
+      - --ethereum-sidecar.server.assets-unlocked-endpoint=mezod:9090
+      - --keyring-backend=file
+      - --key-name=${KEYRING_NAME}
     restart: always
     expose:
       - 7500

--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 4.0.1
+version: 4.1.0
 appVersion: v3.0.1

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -36,7 +36,7 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
 
 ## Values
 

--- a/helm-chart/mezod/templates/statefulset.yaml
+++ b/helm-chart/mezod/templates/statefulset.yaml
@@ -184,12 +184,20 @@ spec:
             {{- else if eq .Values.env.NETWORK "testnet" }}
             - --ethereum-sidecar.server.network=sepolia
             {{- end }}
+            - --ethereum-sidecar.server.assets-unlocked-endpoint=localhost:{{ .Values.service.public.ports.grpc }}
+            - --keyring-backend=file
+            - --key-name=$(KEYRING_NAME)
           env:
             - name: ETHEREUM_ENDPOINT
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.secrets.credentials | quote }}
                   key: ETHEREUM_ENDPOINT
+            - name: KEYRING_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.credentials | quote }}
+                  key: KEYRING_NAME      
           ports:
             - name: client
               containerPort: 7500

--- a/manual/README.md
+++ b/manual/README.md
@@ -141,13 +141,17 @@ The following setup assumes a Unix-like environment.
     # Use Ethereum Sepolia for Mezo testnet.
     mezod ethereum-sidecar \
      --ethereum-sidecar.server.network=mainnet \
-     --ethereum-sidecar.server.ethereum-node-address=wss://eth-mainnet.g.alchemy.com/v2/<redacted>
+     --ethereum-sidecar.server.ethereum-node-address=wss://eth-mainnet.g.alchemy.com/v2/<redacted> \
+     --ethereum-sidecar.server.assets-unlocked-endpoint=localhost:9090 \
+     --keyring-backend=file \
+     --key-name=$MEZOD_KEY
     ```
     The above command assumes you are using the Alchemy provider. Only the WebSocket
-    protocol is supported for the Ethereum node address, i.e. the URL must start
-    with `wss://` (recommended) or `ws://`. Adjust the command according to your
-    setup if needed. For further configuration options, see
-    `mezod ethereum-sidecar --help`.
+    protocol is supported for the Ethereum node address (i.e. the URL must start
+    with `wss://` (recommended) or `ws://`). It also assumes your `mezod` node will be 
+    available at `localhost` and its Cosmos GRPC port is exposed under `9090`.
+    Adjust the command according to your setup if needed. For further configuration options, 
+    see `mezod ethereum-sidecar --help`.
     <br/><br/>
     **If you build `mezod` from source, remember about running `make bindings`
     before building the binary to ensure the `ethereum-sidecar` command works correctly.**

--- a/native/v-kit.sh
+++ b/native/v-kit.sh
@@ -246,7 +246,7 @@ After=network.target
 [Service]
 Restart=no
 ExecStartPre=/bin/echo "Starting ethereum-sidecar systemd initialization..."
-ExecStart=${MEZO_EXEC} ethereum-sidecar --log_format=${MEZOD_LOG_FORMAT} --ethereum-sidecar.server.network=${MEZOD_ETHEREUM_SIDECAR_SERVER_NETWORK} --ethereum-sidecar.server.ethereum-node-address=${MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS}
+ExecStart=${MEZO_EXEC} ethereum-sidecar --log_format=${MEZOD_LOG_FORMAT} --ethereum-sidecar.server.network=${MEZOD_ETHEREUM_SIDECAR_SERVER_NETWORK} --ethereum-sidecar.server.ethereum-node-address=${MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS} --ethereum-sidecar.server.assets-unlocked-endpoint=\"127.0.0.1:9090\" --keyring-backend=\"file\" --key-name=${MEZOD_KEYRING_NAME}
 StandardOutput=journal
 StandardError=journal
 User=root


### PR DESCRIPTION
Closes: https://linear.app/thesis-co/issue/TET-1198/adjustments-in-the-validator-kit

The Ethereum sidecar gained some new flags:
- `ethereum-sidecar.server.assets-unlocked-endpoint` -> Address of the mezod gRPC endpoint used to get AssetsUnlocked events emitted on the Mezo chain
- `keyring-backend` -> Backend used to store the operator key
- `key-name` -> Name of the operator key to extract from keyring (mandatory for bridge validator nodes, optional for other node types)

Those flags are necessary to make the sidecar compatible with the bridge out flow. In this PR, we are adjusting all variants of the V-Kit to set them properly for all validators by default, regardless whether they are promoted to bridge validators or not. Such an approach will simplify future maintenance.