### PR TITLE
Pipe keyring password to Ethereum sidecar

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -43,21 +43,26 @@ services:
     <<: [*platform, *logging, *user,  *networks]
     container_name: ethereum-sidecar
     image: ${DOCKER_IMAGE}
-    entrypoint: [] # Disable the default entrypoint
+    entrypoint: 
+      - /bin/sh
+      - -c
     command:
-      - mezod
-      - ethereum-sidecar
-      - --log_format=json
-      - --ethereum-sidecar.server.ethereum-node-address=${MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS}
-      - --ethereum-sidecar.server.network=${MEZOD_ETHEREUM_SIDECAR_SERVER_NETWORK}
-      - --ethereum-sidecar.server.assets-unlocked-endpoint=mezod:9090
-      - --keyring-backend=file
-      - --key-name=${KEYRING_NAME}
+      - |
+        yes "${KEYRING_PASSWORD}" | mezod ethereum-sidecar \
+          --home=${MEZOD_HOME} \
+          --log_format=json \
+          --ethereum-sidecar.server.ethereum-node-address=${MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS} \
+          --ethereum-sidecar.server.network=${MEZOD_ETHEREUM_SIDECAR_SERVER_NETWORK} \
+          --ethereum-sidecar.server.assets-unlocked-endpoint=mezod:9090 \
+          --keyring-backend=file \
+          --key-name=${KEYRING_NAME}
     restart: always
     expose:
       - 7500
     cap_drop:
       - ALL
+    volumes:
+      - ${LOCAL_BIND_PATH}:${MEZOD_HOME}  
 
   connect-sidecar:
     # Dockerfile: https://github.com/skip-mev/connect/blob/main/contrib/images/connect.sidecar.prod.Dockerfile

--- a/helm-chart/mezod/templates/statefulset.yaml
+++ b/helm-chart/mezod/templates/statefulset.yaml
@@ -174,19 +174,22 @@ spec:
           image: "{{ .Values.image }}:{{ .Values.tag }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           command:
-            - mezod
-            - ethereum-sidecar
-            - --home=/tmp/dummy-data
-            - --log_format=json
-            - --ethereum-sidecar.server.ethereum-node-address=$(ETHEREUM_ENDPOINT)
-            {{- if eq .Values.env.NETWORK "mainnet" }}
-            - --ethereum-sidecar.server.network=mainnet
-            {{- else if eq .Values.env.NETWORK "testnet" }}
-            - --ethereum-sidecar.server.network=sepolia
-            {{- end }}
-            - --ethereum-sidecar.server.assets-unlocked-endpoint=localhost:{{ .Values.service.public.ports.grpc }}
-            - --keyring-backend=file
-            - --key-name=$(KEYRING_NAME)
+            - /bin/sh
+            - -c
+          args:
+            - |
+              yes "$(KEYRING_PASSWORD)" | mezod ethereum-sidecar \
+                --home={{ .Values.env.MEZOD_HOME }} \
+                --log_format=json \
+                --ethereum-sidecar.server.ethereum-node-address=$(ETHEREUM_ENDPOINT) \
+                {{- if eq .Values.env.NETWORK "mainnet" }}
+                --ethereum-sidecar.server.network=mainnet \
+                {{- else if eq .Values.env.NETWORK "testnet" }}
+                --ethereum-sidecar.server.network=sepolia \
+                {{- end }}
+                --ethereum-sidecar.server.assets-unlocked-endpoint=localhost:{{ .Values.service.public.ports.grpc }} \
+                --keyring-backend=file \
+                --key-name=$(KEYRING_NAME)
           env:
             - name: ETHEREUM_ENDPOINT
               valueFrom:
@@ -197,7 +200,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.secrets.credentials | quote }}
-                  key: KEYRING_NAME      
+                  key: KEYRING_NAME
+            - name: KEYRING_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.credentials | quote }}
+                  key: KEYRING_PASSWORD            
           ports:
             - name: client
               containerPort: 7500
@@ -212,8 +220,8 @@ spec:
                 - ALL
             allowPrivilegeEscalation: false
           volumeMounts:
-            - name: dummy-data
-              mountPath: /tmp/dummy-data
+            - name: data
+              mountPath: {{ .Values.env.MEZOD_HOME | quote }}
         #
         # The sidecar container for Skip connect application
         #

--- a/native/v-kit.sh
+++ b/native/v-kit.sh
@@ -183,7 +183,6 @@ configure_mezo() {
 
     ${MEZO_EXEC} toml set \
         ${app_config_file} \
-        -v ethereum-sidecar.server.network="${MEZOD_ETHEREUM_SIDECAR_SERVER_NETWORK}" \
         -v ethereum-sidecar.client.server-address="0.0.0.0:7500" \
         -v api.enable=true \
         -v api.address="tcp://0.0.0.0:1317" \
@@ -246,7 +245,7 @@ After=network.target
 [Service]
 Restart=no
 ExecStartPre=/bin/echo "Starting ethereum-sidecar systemd initialization..."
-ExecStart=${MEZO_EXEC} ethereum-sidecar --log_format=${MEZOD_LOG_FORMAT} --ethereum-sidecar.server.network=${MEZOD_ETHEREUM_SIDECAR_SERVER_NETWORK} --ethereum-sidecar.server.ethereum-node-address=${MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS} --ethereum-sidecar.server.assets-unlocked-endpoint=\"127.0.0.1:9090\" --keyring-backend=\"file\" --key-name=${MEZOD_KEYRING_NAME}
+ExecStart=/bin/bash -c 'yes \"${MEZOD_KEYRING_PASSWORD}\" | ${MEZO_EXEC} ethereum-sidecar --home=${MEZOD_HOME} --log_format=${MEZOD_LOG_FORMAT} --ethereum-sidecar.server.network=${MEZOD_ETHEREUM_SIDECAR_SERVER_NETWORK} --ethereum-sidecar.server.ethereum-node-address=${MEZOD_ETHEREUM_SIDECAR_SERVER_ETHEREUM_NODE_ADDRESS} --ethereum-sidecar.server.assets-unlocked-endpoint=\"127.0.0.1:9090\" --keyring-backend=\"file\" --key-name=${MEZOD_KEYRING_NAME}'
 StandardOutput=journal
 StandardError=journal
 User=root


### PR DESCRIPTION
Ethereum sidecar recently started to require the keyring and a key it can use to execute bridge out attestations. However, if the keyring is `file`, the Ethereum sidecar process prompts for keyring passport several times upon startup. Here we solve that by piping the keyring password through `yes`. We are also setting the home dir wherever missing as it is required to properly extract the keyring.