### PR TITLE
Bump mezod to v9.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Asterisk (*) denotes the latest minor/patch version.
 - `v5.*.*`: from block 8838000 to block 10325250
 - `v6.*.*`: from block 10325250 to block 11688500
 - `v7.*.*`: from block 11688500 to block 11854127
-- `v8.*.*`: from block 11854127 to the current chain tip
+- `v8.*.*`: from block 11854127 to block 12193600
+- `v9.*.*`: from block 12193600 to the current chain tip
 
 #### Version ordering for Mezo Mainnet
 
@@ -120,7 +121,8 @@ Asterisk (*) denotes the latest minor/patch version.
 - `v5.*.*`: from block 5207000 to block 6773500
 - `v6.*.*`: from block 6773500 to block 7691500
 - `v7.*.*`: from block 7691500 to block 7739500
-- `v8.*.*`: from block 7739500 to the current chain tip
+- `v8.*.*`: from block 7739500 to block 8194500
+- `v9.*.*`: from block 8194500 to the current chain tip
 
 ### State sync from snapshot
 

--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 9.0.0
-appVersion: v8.0.0
+version: 10.0.0
+appVersion: v9.0.0

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -36,14 +36,14 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 9.0.0](https://img.shields.io/badge/Version-9.0.0-informational?style=flat-square) ![AppVersion: v8.0.0](https://img.shields.io/badge/AppVersion-v8.0.0-informational?style=flat-square)
+![Version: 10.0.0](https://img.shields.io/badge/Version-10.0.0-informational?style=flat-square) ![AppVersion: v9.0.0](https://img.shields.io/badge/AppVersion-v9.0.0-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | string | `"mezo/mezod"` |  |
-| tag | string | `"v8.0.0"` |  |
+| tag | string | `"v9.0.0"` |  |
 | imagePullPolicy | string | `"Always"` |  |
 | env.NETWORK | string | `"mainnet"` | Select the network to connect to (mainnet or testnet) |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,5 @@
 image: "mezo/mezod"
-tag: "v8.0.0"
+tag: "v9.0.0"
 imagePullPolicy: Always
 
 env:


### PR DESCRIPTION
References: [MEZO-4171](https://linear.app/aspect/issue/MEZO-4171)

## Introduction

Bumping mezod to v9.0.0 release. Validator kit version is bumped to 10.0.0 as they diverged initially.

## Changes

The Helm chart now targets mezod v9.0.0 (chart version 10.0.0). The Docker image tag, chart version, appVersion, and README badges all reflect the new version.

The block ordering sections in the main README are updated for both networks:
- **Testnet**: v8 ends at block 12193600, v9 starts from block 12193600
- **Mainnet**: v8 ends at block 8194500, v9 starts from block 8194500
