### PR TITLE
Bump mezod to v9.1.0

### DIFF
--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 10.0.0
-appVersion: v9.0.0
+version: 10.1.0
+appVersion: v9.1.0

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -36,14 +36,14 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 10.0.0](https://img.shields.io/badge/Version-10.0.0-informational?style=flat-square) ![AppVersion: v9.0.0](https://img.shields.io/badge/AppVersion-v9.0.0-informational?style=flat-square)
+![Version: 10.1.0](https://img.shields.io/badge/Version-10.1.0-informational?style=flat-square) ![AppVersion: v9.1.0](https://img.shields.io/badge/AppVersion-v9.1.0-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | string | `"mezo/mezod"` |  |
-| tag | string | `"v9.0.0"` |  |
+| tag | string | `"v9.1.0"` |  |
 | imagePullPolicy | string | `"Always"` |  |
 | env.NETWORK | string | `"mainnet"` | Select the network to connect to (mainnet or testnet) |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,5 @@
 image: "mezo/mezod"
-tag: "v9.0.0"
+tag: "v9.1.0"
 imagePullPolicy: Always
 
 env:


### PR DESCRIPTION
## Introduction

Bumping mezod to v9.1.0 release. The Helm chart version moves to 10.1.0 to track the minor bump.

## Changes

The Helm chart now targets mezod v9.1.0 (chart version 10.1.0). The Docker image tag, chart version, appVersion, and README badges all reflect the new version. No block ordering changes are needed in the main README since this is a minor bump within the existing `v9.*.*` range.