### PR TITLE
Bump mezod to v10.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Asterisk (*) denotes the latest minor/patch version.
 - `v6.*.*`: from block 10325250 to block 11688500
 - `v7.*.*`: from block 11688500 to block 11854127
 - `v8.*.*`: from block 11854127 to block 12193600
-- `v9.*.*`: from block 12193600 to the current chain tip
+- `v9.*.*`: from block 12193600 to block 12872000
+- `v10.*.*`: from block 12872000 to the current chain tip
 
 #### Version ordering for Mezo Mainnet
 
@@ -122,7 +123,8 @@ Asterisk (*) denotes the latest minor/patch version.
 - `v6.*.*`: from block 6773500 to block 7691500
 - `v7.*.*`: from block 7691500 to block 7739500
 - `v8.*.*`: from block 7739500 to block 8194500
-- `v9.*.*`: from block 8194500 to the current chain tip
+- `v9.*.*`: from block 8194500 to block 8773000
+- `v10.*.*`: from block 8773000 to the current chain tip
 
 ### State sync from snapshot
 

--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 10.1.0
-appVersion: v9.1.0
+version: 11.0.0
+appVersion: v10.0.0

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -36,14 +36,14 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 10.1.0](https://img.shields.io/badge/Version-10.1.0-informational?style=flat-square) ![AppVersion: v9.1.0](https://img.shields.io/badge/AppVersion-v9.1.0-informational?style=flat-square)
+![Version: 11.0.0](https://img.shields.io/badge/Version-11.0.0-informational?style=flat-square) ![AppVersion: v10.0.0](https://img.shields.io/badge/AppVersion-v10.0.0-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | string | `"mezo/mezod"` |  |
-| tag | string | `"v9.1.0"` |  |
+| tag | string | `"v10.0.0"` |  |
 | imagePullPolicy | string | `"Always"` |  |
 | env.NETWORK | string | `"mainnet"` | Select the network to connect to (mainnet or testnet) |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,5 @@
 image: "mezo/mezod"
-tag: "v9.1.0"
+tag: "v10.0.0"
 imagePullPolicy: Always
 
 env:


### PR DESCRIPTION
References: MEZO-4356

## Introduction

Bumping mezod to v10.0.0 release. Validator kit version is bumped to 11.0.0 as they diverged initially.

## Changes

The Helm chart now targets mezod v10.0.0 (chart version 11.0.0). The Docker image tag, chart version, appVersion, and README badges all reflect the new version.

The block ordering sections in the main README are updated for both networks:
- **Testnet**: v9 ends at block 12872000, v10 starts from block 12872000
- **Mainnet**: v9 ends at block 8773000, v10 starts from block 8773000