### PR TITLE
Bump mezod to v11.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Asterisk (*) denotes the latest minor/patch version.
 - `v7.*.*`: from block 11688500 to block 11854127
 - `v8.*.*`: from block 11854127 to block 12193600
 - `v9.*.*`: from block 12193600 to block 12872000
-- `v10.*.*`: from block 12872000 to the current chain tip
+- `v10.*.*`: from block 12872000 to block 13206900
+- `v11.*.*`: from block 13206900 to the current chain tip
 
 #### Version ordering for Mezo Mainnet
 
@@ -124,7 +125,8 @@ Asterisk (*) denotes the latest minor/patch version.
 - `v7.*.*`: from block 7691500 to block 7739500
 - `v8.*.*`: from block 7739500 to block 8194500
 - `v9.*.*`: from block 8194500 to block 8773000
-- `v10.*.*`: from block 8773000 to the current chain tip
+- `v10.*.*`: from block 8773000 to block 9275000
+- `v11.*.*`: from block 9275000 to the current chain tip
 
 ### State sync from snapshot
 

--- a/helm-chart/mezod/Chart.yaml
+++ b/helm-chart/mezod/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mezod
-version: 11.0.0
-appVersion: v10.0.0
+version: 12.0.0
+appVersion: v11.0.0

--- a/helm-chart/mezod/README.md
+++ b/helm-chart/mezod/README.md
@@ -36,14 +36,14 @@ kubectl -n <NAMESPACE> create secret generic <SECRET_NAME> \
 
 # mezod
 
-![Version: 11.0.0](https://img.shields.io/badge/Version-11.0.0-informational?style=flat-square) ![AppVersion: v10.0.0](https://img.shields.io/badge/AppVersion-v10.0.0-informational?style=flat-square)
+![Version: 12.0.0](https://img.shields.io/badge/Version-12.0.0-informational?style=flat-square) ![AppVersion: v11.0.0](https://img.shields.io/badge/AppVersion-v11.0.0-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image | string | `"mezo/mezod"` |  |
-| tag | string | `"v10.0.0"` |  |
+| tag | string | `"v11.0.0"` |  |
 | imagePullPolicy | string | `"Always"` |  |
 | env.NETWORK | string | `"mainnet"` | Select the network to connect to (mainnet or testnet) |
 | env.PUBLIC_IP | string | `"CHANGE_ME"` | Set public IP address of the validator |

--- a/helm-chart/mezod/values.yaml
+++ b/helm-chart/mezod/values.yaml
@@ -1,5 +1,5 @@
 image: "mezo/mezod"
-tag: "v10.0.0"
+tag: "v11.0.0"
 imagePullPolicy: Always
 
 env:


### PR DESCRIPTION
References: [MEZO-4077](https://linear.app/thesis-co/issue/MEZO-4077/the-v1100-mezod-release-mainnet)

## Introduction

Bumping mezod to v11.0.0 release. Validator kit version is bumped to 12.0.0 as they diverged initially.

## Changes

The Helm chart now targets mezod v11.0.0 (chart version 12.0.0). The Docker image tag, chart version, appVersion, and README badges all reflect the new version.

The block ordering sections in the main README are updated for both networks:
- **Testnet**: v10 ends at block 13206900, v11 starts from block 13206900
- **Mainnet**: v10 ends at block 9275000, v11 starts from block 9275000
