### PR TITLE
Default on mezod defaults for exposed apis

### DIFF
--- a/native/v-kit.sh
+++ b/native/v-kit.sh
@@ -191,7 +191,6 @@ configure_mezo() {
         -v grpc-web.enable=true \
         -v json-rpc.enable=true \
         -v json-rpc.address="0.0.0.0:8545" \
-        -v json-rpc.api="eth,txpool,personal,net,debug,web3" \
         -v json-rpc.ws-address="0.0.0.0:8546" \
         -v json-rpc.metrics-address="0.0.0.0:6065" \
         -v pruning="nothing"


### PR DESCRIPTION
The native deployment should rely on mezod defaults, just like docker and helm options for consistency. Also, there is no point in enabling personal or debug APIs by default.